### PR TITLE
fix: explicitly require forwardable

### DIFF
--- a/lib/tkseal.rb
+++ b/lib/tkseal.rb
@@ -6,6 +6,7 @@ require "base64"
 require "ostruct"
 require "diffy"
 require "thor"
+require "forwardable"
 
 require_relative "tkseal/version"
 require_relative "tkseal/secret"


### PR DESCRIPTION
I was getting errors with forwardable not found. Explicitly requiring it fixed the problem.