### PR TITLE
fix shell quoting

### DIFF
--- a/lib/tkseal/kubeseal.rb
+++ b/lib/tkseal/kubeseal.rb
@@ -6,7 +6,7 @@ module TKSeal
     end
 
     def self.seal(context:, namespace:, name:, value:)
-      `printf "%s" "#{value}" | kubeseal --raw --namespace #{namespace} --name #{name} --context #{context}`
+      `printf "%s" '#{value}' | kubeseal --raw --namespace #{namespace} --name #{name} --context #{context}`
     end
     # :nocov:
   end


### PR DESCRIPTION
As is, `"$dollarsign"` or ``"`whoami`"`` are going to have unexpected results.