### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ The tool knows which kuberentes context and namespace to use by reading the conf
 
 ## Dependencies
 * `ruby` > 2.7
-* `kubectl`
-* `tk`
-* `kubeseal`
-
-
+* `kubectl` (
+* Grafana Tanka (`tk`) ([install instructions](https://tanka.dev/install/))
+* `kubeseal` ([install instructions](https://github.com/bitnami-labs/sealed-secrets?tab=readme-ov-file#kubeseal))
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ The tool knows which kuberentes context and namespace to use by reading the conf
 
 ## Installation
 
-    $ gem install tkseal --version "WHATEVER_THE_CURRENT_VERSION_IS" --source "https://YOUR_GITHUB_USERNAME:YOUR_GITHUB_PAT_WITH_READ_PACKAGES@rubygems.pkg.github.com/mlibrary"
-
+```bash
+git clone https://github.com/mlibrary/tkseal/
+cd tkseal
+gem build tkseal.gemspec
+gem install ./tkseal-1.2.4.gem # or whatever the current version is
+```
 
 ## Usage
 ```

--- a/tkseal.gemspec
+++ b/tkseal.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor"
   spec.add_dependency "diffy", "~> 3.4", ">= 3.4.2"
+  spec.add_dependency "base64"
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Installing from the github gem registry hasn't worked for anybody in my group that I'm aware. These instructions worked for me and @lisepul.

I also added links to the installation instructions for kubeseal and tanka.