### PR TITLE
update testing matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [3.2, 3.3, 3.4]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/tkseal/secret_state.rb
+++ b/lib/tkseal/secret_state.rb
@@ -1,6 +1,7 @@
 module TKSeal
   class SecretState
     extend Forwardable
+
     def_delegators :@tk_env, :context, :namespace
     attr_reader :plain_secrets_file_path, :sealed_secrets_file_path
     def initialize(tk_env_path, configuration = TKSeal::Configuration, tk_env_getter = TKSeal::TK::Environment)

--- a/tkseal.gemspec
+++ b/tkseal.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["tkseal"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "ostruct"
   spec.add_dependency "thor"
   spec.add_dependency "diffy", "~> 3.4", ">= 3.4.2"
   spec.add_dependency "base64"


### PR DESCRIPTION
Changes the testing matrix to 3.2 - 3.4
Adds `ostruct` as a dependency to get rid of the warning.